### PR TITLE
Update Startup.cs

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.MyCat.Proxy/Startup.cs
+++ b/src/Pomelo.EntityFrameworkCore.MyCat.Proxy/Startup.cs
@@ -114,19 +114,19 @@ namespace Pomelo.EntityFrameworkCore.MyCat.Proxy
             {
                 if (s.Keys.Count() != 1)
                     continue;
-                string ruleXml;
-                string funcXml;
+                string ruleXml="";
+                string funcXml="";
                 if (IsUnder16)
                 {
-                    ruleXml = $@"
+                    ruleXml += $@"
 	<tableRule name=""{ database }_{ s.TableName }_rule"">
 		<rule>
-			<columns>{ string.Join(",", s.Keys.First()) }</columns>
+			<columns>{ s.Keys.First() }</columns>
 			<algorithm>{ database }_{ s.TableName }_func</algorithm>
 		</rule>
 	</tableRule>
 ";
-                    funcXml = $@"
+                    funcXml += $@"
 	<function name=""{ database }_{ s.TableName }_func"" class=""org.opencloudb.route.function.PartitionByMod"">
 		<property name=""count"">{ s.DataNodes.Count() }</property>
 	</function>
@@ -134,15 +134,15 @@ namespace Pomelo.EntityFrameworkCore.MyCat.Proxy
                 }
                 else // 1.6+
                 {
-                    ruleXml = $@"
+                    ruleXml += $@"
 	<tableRule name=""{ database }_{ s.TableName }_rule"">
 		<rule>
-			<columns>{ string.Join(",", s.Keys.First()) }</columns>
+			<columns>{s.Keys.First() }</columns>
 			<algorithm>{ database }_{ s.TableName }_func</algorithm>
 		</rule>
 	</tableRule>
 ";
-                    funcXml = $@"
+                    funcXml += $@"
 	<function name=""{ database }_{ s.TableName }_func"" class=""io.mycat.route.function.PartitionByMod"">
 		<property name=""count"">{ s.DataNodes.Count()}</property>
 	</function>


### PR DESCRIPTION
rule.xml :
`<tableRule><rule><columns>ID,ID,ID</columns></rule></tableRule>`
columns does not support multiple values.
So,The most simple way to modify the method is to modify the method GenerateRuleXml(List<MyCatTable> Schema, List<MyCatDataNode> DataNodes, string database, bool IsUnder16)

Create a rule for each MycatTable.
